### PR TITLE
Add U2211 (mathematical sum). Move sumint to sint.

### DIFF
--- a/dotXCompose
+++ b/dotXCompose
@@ -218,6 +218,8 @@ include "%L"
 <Multi_key> <minus> <a>	      	  	: "ª"   U00AA		# FEMININE ORDINAL INDICATOR
 <Multi_key> <minus> <o>			: "º"	U00BA		# MASCULINE ORDINAL INDICATOR
 
+# See also U03A3 (Greek capital sigma)
+<Multi_key> <Multi_key> <s> <u> <m>	: "∑"	U2211		# N-ARY SUMMATION
 # OK, absolutely cannot believe we made it this long without NABLA or INTEGRAL
 # or PARTIAL DIFFERENTIAL
 <Multi_key> <Multi_key> <i> <n> <t>	: "∫"	U222B		# INTEGRAL
@@ -232,7 +234,7 @@ include "%L"
 <Multi_key> <Multi_key> <o> <i> <i> <n> <t>	: "∯"	U222F		# SURFACE INTEGRAL
 <Multi_key> <Multi_key> <o> <i> <i> <i> <n> <t>	: "∰"	U2230		# VOLUME INTEGRAL
 <Multi_key> <Multi_key> <g> <i> <n> <t>	: "⨘"	U2A18		# GEOMETRIC INTEGRAL
-<Multi_key> <Multi_key> <s> <u> <m> <i> <n> <t>	: "⨋"	U2A0B		# SUM/INTEGRAL
+<Multi_key> <Multi_key> <s> <i> <n> <t>	: "⨋"	U2A0B		# SUM/INTEGRAL
 #Now for some WTF integrals: ⨙ ⨚ 	
 <Multi_key> <Multi_key> <d> <e> <l>	: "∇"	U2207	        # NABLA
 <Multi_key> <Multi_key> <p> <a> <r> <t>   : "∂" U2202		# PARTIAL DIFFERENTIAL


### PR DESCRIPTION
Add <Multi_key> <Multi_key> <s> <u> <m> for the mathematical symbol
n-ary sum. Needed to move ··sumint to ··sint to make room. But I think
it fits with ··gint.

I know there is a certain overlap with Greek capital sigma. I think it can’t hurt to have both and have sum available under a mnemonic name.
