### PR TITLE
Some chat aids - And one conflict fixed (introduced by myself)

### DIFF
--- a/dotXCompose
+++ b/dotXCompose
@@ -40,7 +40,8 @@ include "%L"
 <Multi_key> <comma> <apostrophe>	: "‚"	U201A		# SINGLE LOW-9 QUOTATION MARK (quote resembling a comma)
 <Multi_key> <comma> <quotedbl>		: "„"	U201E		# DOUBLE LOW-9 QUOTATION MARK
 <Multi_key> <less> <bar>		: "↵"	U21B5		# DOWNWARDS ARROW WITH CORNER LEFTWARDS
-<Multi_key> <o> <period>		: "•"	U2022		# BULLET
+# The bullet was <o> <period>, but it clashes with ꙭ
+<Multi_key> <asterisk> <1>		: "•"	U2022		# BULLET
 # By default <Multi_key> <period> <period> does this, but we broke that with the ... binding.
 <Multi_key> <o> <underscore>		: "⁃"   U2043		# HYPHEN BULLET
 <Multi_key> <o> <comma>			: "·"	periodcentered	# MIDDLE DOT


### PR DESCRIPTION
I added ꙭ, Ꙭ, ꙫ, Ꙫ as chat aids — However, the first one introduced a conflict on • (which I use quite often). While • would take precedence (as it got there earlier), I moved it from &lt;o&gt; &lt;period&gt; to &lt;asterisk&gt; &lt;1&gt; as it does not (IMO) have a strong reason to its sequence, and ꙭ makes  visual sense with &lt;o&gt; &lt;period&gt; &lt;o&gt;.

Of course, if you disagree with me, I'll move my chat aids elsewhere :)
