### PR TITLE
Added all subscripts from blocks U+208x and U+209x.

### DIFF
--- a/dotXCompose
+++ b/dotXCompose
@@ -404,17 +404,41 @@ include "%L"
 
 # The system file gives us subscript numbers, plus/minus, and parens.  But
 # there are letters missing.  It would be nice to have at least a few of them.
-<Multi_key> <underscore> <i>  	       :  "ᵢ"  U1D62   	  # LATIN SUBSCRIPT SMALL LETTER I
-<Multi_key> <underscore> <o>	       :  "ₒ"  U2092	  # LATIN SUBSCRIPT SMALL LETTER O
-<Multi_key> <underscore> <x>	       :  "ₓ"  U2093	  # LATIN SUBSCRIPT SMALL LETTER X
-<Multi_key> <underscore> <j>	       :  "ⱼ"  U2C7C	  # LATIN SUBSCRIPT SMALL LETTER J
-# Awaiting common font support for these...
-<Multi_key> <underscore> <k>           :  "ₖ"  U2096	  # LATIN SUBSCRIPT SMALL LETTER K
-<Multi_key> <underscore> <m>	       :  "ₘ"  U2098	  # LATIN SUBSCRIPT SMALL LETTER M
-<Multi_key> <underscore> <n>	       :  "ₙ"  U2099	  # LATIN SUBSCRIPT SMALL LETTER N
-<Multi_key> <underscore> <minus>       : "₋"   U208B	  # SUBSCRIPT MINUS
-<Multi_key> <underscore> <plus>	       : "₊"   U208A	  # SUBSCRIPT PLUS
 
+# block U+208x
+<Multi_key> <underscore> <0>  	       : "₀"  U2080   	  # SUBSCRIPT ZERO
+<Multi_key> <underscore> <1>  	       : "₁"  U2081   	  # SUBSCRIPT ONE
+<Multi_key> <underscore> <2>  	       : "₂"  U2082   	  # SUBSCRIPT TWO
+<Multi_key> <underscore> <3>  	       : "₃"  U2083   	  # SUBSCRIPT THREE
+<Multi_key> <underscore> <4>  	       : "₄"  U2084   	  # SUBSCRIPT FOUR
+<Multi_key> <underscore> <5>  	       : "₅"  U2085   	  # SUBSCRIPT FIVE
+<Multi_key> <underscore> <6>  	       : "₆"  U2086   	  # SUBSCRIPT SIX
+<Multi_key> <underscore> <7>  	       : "₇"  U2087   	  # SUBSCRIPT SEVEN
+<Multi_key> <underscore> <8>  	       : "₈"  U2088   	  # SUBSCRIPT EIGHT
+<Multi_key> <underscore> <9>  	       : "₉"  U2089   	  # SUBSCRIPT NONE
+<Multi_key> <underscore> <plus>	       : "₊"  U208A	  # SUBSCRIPT PLUS
+<Multi_key> <underscore> <minus>       : "₋"  U208B	  # SUBSCRIPT MINUS
+<Multi_key> <underscore> <=>           : "₌"  U208C	  # SUBSCRIPT EQUALS SIGN
+<Multi_key> <underscore> <(>           : "₍"  U208D	  # SUBSCRIPT LEFT PARENTHESIS
+<Multi_key> <underscore> <)>           : "₎"  U208E	  # SUBSCRIPT RIGHT PARENTHESIS
+
+# block U+209x
+<Multi_key> <underscore> <a>	       : "ₐ"  U2090	  # LATIN SUBSCRIPT SMALL LETTER A
+<Multi_key> <underscore> <e>	       : "ₑ"  U2091	  # LATIN SUBSCRIPT SMALL LETTER E
+<Multi_key> <underscore> <o>	       : "ₒ"  U2092	  # LATIN SUBSCRIPT SMALL LETTER O
+<Multi_key> <underscore> <x>	       : "ₓ"  U2093	  # LATIN SUBSCRIPT SMALL LETTER X
+<Multi_key> <underscore> <h>	       : "ₕ"  U2095	  # LATIN SUBSCRIPT SMALL LETTER H
+<Multi_key> <underscore> <k>           : "ₖ"  U2096	  # LATIN SUBSCRIPT SMALL LETTER K
+<Multi_key> <underscore> <l>           : "ₗ"  U2097	  # LATIN SUBSCRIPT SMALL LETTER L
+<Multi_key> <underscore> <m>	       : "ₘ"  U2098	  # LATIN SUBSCRIPT SMALL LETTER M
+<Multi_key> <underscore> <n>	       : "ₙ"  U2099	  # LATIN SUBSCRIPT SMALL LETTER N
+<Multi_key> <underscore> <p>	       : "ₚ"  U209A	  # LATIN SUBSCRIPT SMALL LETTER P
+<Multi_key> <underscore> <s>	       : "ₛ"  U209B	  # LATIN SUBSCRIPT SMALL LETTER S
+<Multi_key> <underscore> <t>	       : "ₜ"  U209C	  # LATIN SUBSCRIPT SMALL LETTER T
+
+# subscripts in other blocks
+<Multi_key> <underscore> <i>  	       : "ᵢ"  U1D62   	  # LATIN SUBSCRIPT SMALL LETTER I
+<Multi_key> <underscore> <j>           : "ⱼ"  U2C7C	  # LATIN SUBSCRIPT SMALL LETTER J
 
 # Custom additions: Greek letters.  Mapping corresponds to Emacs Greek
 # input method.  Aristotle Pagaltzis informs me that this is the


### PR DESCRIPTION
All subscripts for 0-9, (, ), +, -, =, and some letters in those blocks were added with `<Multi_key> <underscore>`.