### PR TITLE
Make emojitrans2.pl not assume location of perl installation

### DIFF
--- a/emojitrans2.pl
+++ b/emojitrans2.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -p
+#!/usr/bin/env -S perl -p
 use feature 'unicode_strings';
 use utf8;
 BEGIN { binmode(STDOUT, ":utf8");


### PR DESCRIPTION
This fixes building it on NixOS, where `perl` is installed somewhere entirely else.