### PR TITLE
Keep working tree clean after `make`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 emoji.compose
 modletters.compose
+maths.compose
+tags.compose


### PR DESCRIPTION
maths.compose and tags.compose are created by `make` command. Git should ignore them.