### PR TITLE
Use GREEK SMALL LETTER MU instead of MICRO SIGN

### DIFF
--- a/dotXCompose
+++ b/dotXCompose
@@ -382,7 +382,7 @@ include "%L"
 <Multi_key> <quotedbl> <period>	   	: "∵"	U2235  		# BECAUSE
 <Multi_key> <Multi_key> <b> <e> <c> <a> <u> <s> <e>	   	: "∵"	U2235  		# BECAUSE
 <Multi_key> <percent> <percent>		: "‱"	U2031	# PER TEN THOUSAND (basis points)
-<Multi_key> <slash> <u>                : "µ"   U00B5      # MICRO SIGN
+<Multi_key> <slash> <u>                : "μ"   U03BC      # GREEK SMALL LETTER MU
 # Ordinal indicators, for femenine and masculine, used in Romance languages
 <Multi_key> <minus> <a>	      	  	: "ª"   U00AA		# FEMININE ORDINAL INDICATOR
 <Multi_key> <minus> <o>			: "º"	U00BA		# MASCULINE ORDINAL INDICATOR


### PR DESCRIPTION
U+03BC GREEK SMALL LETTER MU is the compatibility decomposition of U+00B5 MICRO SIGN, and UTR 25 (https://www.unicode.org/reports/tr25/) section 2.5 states that "U+03BC μ is the preferred character in a Unicode context".